### PR TITLE
Added CLI option -d to specify working directory.

### DIFF
--- a/launcher.c
+++ b/launcher.c
@@ -142,11 +142,20 @@ static wchar_t* SetEnv(wchar_t* conffile) {
 	return msystem;
 }
 
+void FixPathSlash(wchar_t* path) {
+	while (*path) {
+		if (*path == L'/') {
+			*path = L'\\';
+		}
+		++path;
+	}
+}
+
 int wmain(int argc, wchar_t* argv[]) {
 	PROCESS_INFORMATION child;
 	int code;
+	int i;
 	size_t buflen;
-	size_t workdirlen;
 	wchar_t* buf;
 	wchar_t* tmp;
 	wchar_t* args;
@@ -156,20 +165,28 @@ int wmain(int argc, wchar_t* argv[]) {
 	wchar_t confpath[PATH_MAX];
 	wchar_t workdir[PATH_MAX];
 
+	wchar_t* cmdline =
+		L"%s\\usr\\bin\\mintty.exe"
+		L" -i '%s'"
+		L" -o 'AppLaunchCmd=%s'"
+		L" -o 'AppID=MSYS2.Shell.%s.%d'"
+		L" -o 'AppName=MSYS2 %s Shell'"
+		L" -t 'MSYS2 %s Shell'"
+		L" --store-taskbar-properties"
+		L" -- %s %s";
+
+	wchar_t* cmdargs[] = {
+		L"-",
+		L"/usr/bin/sh -lc '\"$@\"' sh"
+	};
+
 	code = GetModuleFileName(NULL, exepath, sizeof(exepath) / sizeof(exepath[0]));
 	if (code == 0) {
 		ShowLastError(L"Could not determine executable path");
 		return __LINE__;
 	}
 
-	tmp = exepath;
-	while (true) {
-		tmp = wcschr(tmp, L'/');
-		if (tmp == NULL) {
-			break;
-		}
-		*tmp = L'\\';
-	}
+	FixPathSlash(exepath);
 
 	wcscpy(msysdir, exepath);
 	tmp = wcsrchr(msysdir, L'\\');
@@ -201,77 +218,64 @@ int wmain(int argc, wchar_t* argv[]) {
 		ShowLastError(L"Could not set environment variable");
 	}
 
-	// can break, but hopefully won't for most use cases
 	args = GetCommandLine();
-	if (args[0] == L'"') {
-		args++;
+
+	// forward args
+	args = wcsstr(args, argv[0]) + wcslen(argv[0]);
+	if (*args == L'"') {
+		++args;
 	}
-	args += wcslen(argv[0]);
-	if (args[0] == L'"') {
-		args++;
+	while (*args == L' ') {
+		++args;
 	}
 
 	// extract workdir from -d option
 	if (argc > 2 && wcscmp(L"-d", argv[1]) == 0) {
-		int i = 0;
 
 		// forward args
 		args = wcsstr(args, argv[1]) + wcslen(argv[1]);
-	
+		while (*args == L' ') {
+			++args;
+		}
+
 		// extract workdir and strip begining and trailing quotes
 		tmp = argv[2];
-		if (tmp[0] == L'"') {
+		if (*tmp == L'"') {
 			tmp++;
 		}
+		i = 0;
 		while (i < PATH_MAX && *tmp) {
-			workdir[i++] = *tmp++;
+			workdir[i++] = (*tmp == L'/') ? L'\\' : *tmp;
+			++tmp;
 		}
-		if (i > 0) {
-			if (i < PATH_MAX) {
-				if (workdir[i-1] == L'"') {
-					i--;
-				}
-				workdir[i] = L'\0';
-			} else {
-				workdir[--i] = L'\0';
-			}
-		} else {
-			workdir[0] = L'\0';
+		if (i > 0 && (i == PATH_MAX || workdir[i-1] == L'"')) {
+			--i;
 		}
-		
-		// replace forward slash to backslash in workdir
-		tmp = workdir;
-		while (true) {
-			tmp = wcschr(tmp, L'/');
-			if (tmp == NULL) {
-				break;
-			}
-			*tmp = L'\\';
+		// strip trailing slash
+		if (!i && (workdir[i-1] == L'\\')) {
+			--i;
 		}
-	
-		// strip trailing slash in workdir
-		workdirlen = wcslen(workdir);
-		if (workdirlen && workdir[workdirlen - 1] == L'\\') {
-			workdir[--workdirlen] = L'\0';
+		workdir[i] = L'\0';
+
+		if (!*workdir) {
+			ShowError(L"Working directory not specified", argv[2], 0);
+			return __LINE__;
 		}
 		
 		// forward args
 		args = wcsstr(args, argv[2]) + wcslen(argv[2]);
-		while (*args++ == L' ') {
-			// noop
+		if (*args == L'"') {
+			args++;
 		}
-	
-		if (workdirlen == 0) {
-			ShowError(L"Working directory not specified", argv[2], 0);
-			return __LINE__;
+		while (*args == L' ') {
+			++args;
 		}
-	
+
 	} else {
-		workdir[0] = L'\0';
-		workdirlen = 0;
+		*workdir = L'\0';
 	}
-	
-	if ((argc > 1 && !workdirlen) || (argc > 3 && workdirlen)) {
+
+	if ((argc > 1 && !*workdir) || (argc > 3 && *workdir)) {
 		code = SetEnvironmentVariable(L"CHERE_INVOKING", L"1");
 		if (code == 0) {
 			ShowLastError(L"Could not set environment variable");
@@ -287,16 +291,30 @@ int wmain(int argc, wchar_t* argv[]) {
 			ShowError(L"Could not allocate memory", L"", 0);
 			return __LINE__;
 		}
-		code = swprintf(buf, buflen, L"%s\\usr\\bin\\mintty.exe -i '%s' -o 'AppLaunchCmd=%s' -o 'AppID=MSYS2.Shell.%s.%d' -o 'AppName=MSYS2 %s Shell' -t 'MSYS2 %s Shell' --store-taskbar-properties -- %s %s", msysdir, exepath, exepath, msystem, APPID_REVISION, msystem, msystem, (argc == 1 || (argc == 3 && workdirlen)) ? L"-" : L"/usr/bin/sh -lc '\"$@\"' sh", args);
+		code = swprintf(buf, buflen, cmdline,
+			msysdir,
+			exepath,
+			exepath,
+			msystem,
+			APPID_REVISION,
+			msystem,
+			msystem,
+			(argc == 1 || (argc == 3 && *workdir)) ? cmdargs[0] : cmdargs[1],
+			args
+		);
 		buflen *= 2;
 	}
 	if (code < 0) {
 		ShowErrno(L"Could not write to buffer");
+		free(buf);
+		buf = NULL;
 		return __LINE__;
 	}
 
-	child = StartChild(buf, workdirlen ? workdir : NULL);
+	child = StartChild(buf, *workdir ? workdir : NULL);
 	if (child.hProcess == NULL) {
+		free(buf);
+		buf = NULL;
 		return __LINE__;
 	}
 


### PR DESCRIPTION
To specify the working directory, user can use the -d option and specify the directory path,
this option should be first in the list of arguments of launcher. Paths with spaces, in quotation marks, and with letters of national alphabets are correctly processed.

```bash
%MSYS2_HOME%\mingw64.exe -d "%PROGRAMFILES%" bash
```

The creation of explorer context menus is greatly simplified:

```bash
%MSYS2_HOME%\mingw64.exe -d "%V%" bash
```

